### PR TITLE
Fix crash on unknown locale

### DIFF
--- a/aiohttp_babel/middlewares.py
+++ b/aiohttp_babel/middlewares.py
@@ -1,6 +1,7 @@
 import asyncio
 from speaklater import is_lazy_string, make_lazy_string
 from aiohttp_babel import locale
+from babel.core import UnknownLocaleError
 from threading import local
 
 _thread_locals = local()
@@ -25,7 +26,10 @@ def babel_middleware(app, handler):
         if not _code:
             # get locale from browser
             locale_code = request.headers.get('ACCEPT-LANGUAGE', 'en')[:2]
-            _code = str(locale.Locale.parse(locale_code, sep='-'))
+            try:
+                _code = str(locale.Locale.parse(locale_code, sep='-'))
+            except (ValueError, UnknownLocaleError):
+                pass
 
         _locale = locale.get(_code)
         _thread_locals.locale = request.locale = _locale


### PR DESCRIPTION
```
Traceback:
ValueError: expected only letters, got '*,'
  File "aiohttp/web_server.py", line 62, in handle_request
    resp = yield from self._handler(request)
  File "aiohttp/web.py", line 270, in _handle
    resp = yield from handler(request)
  File "aiohttp_babel/middlewares.py", line 28, in middleware
    _code = str(locale.Locale.parse(locale_code, sep='-'))
  File "babel/core.py", line 250, in parse
    parts = parse_locale(identifier, sep=sep)
  File "babel/core.py", line 902, in parse_locale
    raise ValueError('expected only letters, got %r' % lang)

Error handling request
```

Now, instead of crash, using locale code from `Locale.get_closest`.
If no closest exists using default local instead.