### PR TITLE
use babel NullTranslations

### DIFF
--- a/aiohttp_babel/locale.py
+++ b/aiohttp_babel/locale.py
@@ -22,11 +22,10 @@
             fixed implementation of translations merge process in
             load_gettext_translations
 """
-import gettext
 import logging
 import os
 
-from babel.support import Translations
+from babel.support import Translations, NullTranslations
 from babel.core import Locale as BabelCoreLocale
 from babel import dates
 
@@ -126,7 +125,7 @@ class Locale(BabelCoreLocale):
             cls._cache = {}
         if code not in cls._cache:
             assert code in _supported_locales
-            translations = _translations.get(code, gettext.NullTranslations())
+            translations = _translations.get(code, NullTranslations())
             locale = cls.parse(code)
             locale.translations = translations
             cls._cache[code] = locale


### PR DESCRIPTION
gettext.NullTranslations has no method ugettext, which is called in translate()